### PR TITLE
Tput now resets colors instead of using white

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -77,8 +77,8 @@ source ~/.config/zsh/zsh-plugins/fzf-tab/fzf-tab.plugin.zsh
 
 PCOLOR=$(echo $PCOLOR |  grep -o '[[:digit:]]*' | cut -c 4)
 
-prompt='%B%F{$PCOLOR}%2~% %F{7}$(gitprompt) %B%F{$PCOLOR}  %b'
-RPROMPT='%F{7}%n@%m%'
+prompt='%B%F{$PCOLOR}%2~% %F{sgr0}$(gitprompt) %B%F{$PCOLOR}  %b'
+RPROMPT='%F{sgr0}%n@%m%'
 
 gitprompt
 autols

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -77,8 +77,8 @@ source ~/.config/zsh/zsh-plugins/fzf-tab/fzf-tab.plugin.zsh
 
 PCOLOR=$(echo $PCOLOR |  grep -o '[[:digit:]]*' | cut -c 4)
 
-prompt='%B%F{$PCOLOR}%2~% %F{sgr0}$(gitprompt) %B%F{$PCOLOR}  %b'
-RPROMPT='%F{sgr0}%n@%m%'
+prompt='%B%F{$PCOLOR}%2~% %F{7}$(gitprompt) %B%F{$PCOLOR}  %b'
+RPROMPT='%F{7}%n@%m%'
 
 gitprompt
 autols

--- a/zsh/autostart
+++ b/zsh/autostart
@@ -11,7 +11,7 @@ RED=$(tput setaf 1)
 BLUE=$(tput setaf 4)
 GREEN=$(tput setaf 2)
 PINK=$(tput setaf 5)
-STOP=$(tput sgr0)
+STOP=$(tput setaf 7)
 if [ -f /etc/os-release ]; then
     . /etc/os-release
     OS=$(printf $PRETTY_NAME | tr '[:upper:]' '[:lower:]')

--- a/zsh/autostart
+++ b/zsh/autostart
@@ -11,7 +11,7 @@ RED=$(tput setaf 1)
 BLUE=$(tput setaf 4)
 GREEN=$(tput setaf 2)
 PINK=$(tput setaf 5)
-STOP=$(tput setaf 7)
+STOP=$(tput sgr0)
 if [ -f /etc/os-release ]; then
     . /etc/os-release
     OS=$(printf $PRETTY_NAME | tr '[:upper:]' '[:lower:]')

--- a/zsh/autostart
+++ b/zsh/autostart
@@ -11,7 +11,7 @@ RED=$(tput setaf 1)
 BLUE=$(tput setaf 4)
 GREEN=$(tput setaf 2)
 PINK=$(tput setaf 5)
-STOP=$(tput setaf 7)
+STOP=$(tput sgr0)
 
 if [ -f /etc/os-release ]; then
     . /etc/os-release


### PR DESCRIPTION
The foreground color is now reset, which allows the terminal itself to provide its own foreground. This makes it more agnostic for different palettes, especially when differentiating light and dark colorschemes. Bingus + Bongus compatibility moment. 